### PR TITLE
Uses a global tile counter for tile ID. Closes #16.

### DIFF
--- a/static/scripts/board.js
+++ b/static/scripts/board.js
@@ -3,6 +3,7 @@ let lettersArray = [];
 let grabbedTile = null;
 let targetCell = null;
 let originCell = null;
+let numberOfTiles = 0;
 
 const options = false;
 
@@ -35,8 +36,10 @@ const renderBoard = (arr) => {
 }
 
 const createTiles = (lettersArray) => {
-  const tilesArray =  lettersArray.map((letter, index) => {
-    return `<div class="cell"><span class="tile" data-tile-id="${index}" draggable="true">${letter}</span></div>`;
+  let tilesArray = [];
+  Array.prototype.forEach.call(lettersArray, function(letter) {
+    tilesArray.push(`<div class="cell"><span class="tile" data-tile-id="${numberOfTiles}" draggable="true">${letter}</span></div>`);
+    numberOfTiles += 1;
   });
 
   return tilesArray;


### PR DESCRIPTION
As suggested, this keeps a global tile counter and uses that for the ID.