### PR TITLE
Refactor to async load the board

### DIFF
--- a/static/scripts/board.js
+++ b/static/scripts/board.js
@@ -62,36 +62,6 @@ const createTiles = (lettersArray) => {
   return tilesArray;
 };
 
-const populateBoard = () => {
-  let board = document.getElementById("board");
-  for (let r=0; r < rows; r++) {
-    for (let c=0; c < columns; c++) {
-      board.innerHTML += `<div class="cell" data-row=${r} data-column=${c}></div>`;
-    }
-  }
-
-  // Attach the listeners to the grid cells
-  document.querySelectorAll(".cell").forEach((cell) => {
-    cell.addEventListener("dragenter", handleDragEnter, options);
-    cell.addEventListener("dragleave", handleDragLeave, options);
-    cell.addEventListener("dragover", handleDragOver, options);
-
-    cell.addEventListener("dragend", handleDragEnd, options);
-    cell.addEventListener("drop", handleDrop, options);
-  });
-
-  centerBoard();
-};
-
-centerBoard = () => {
-  const boardViewport = document.getElementById("board-viewport");
-  const board = document.getElementById("board");
-  const scrollPositionX =  board.offsetLeft + (board.offsetWidth / 2);
-  const scrollPositionY = board.offsetTop + (board.offsetHeight / 3);
-  boardViewport.scrollLeft = scrollPositionX;
-  boardViewport.scrollTop = scrollPositionY;
-
-}
 
 const fillCells = (parentId, childrenArrayOrCellNumber) => {
   const parent = document.getElementById(parentId);
@@ -156,58 +126,6 @@ const handleDragStart = e => {
   e.dataTransfer.effectAllowed = "move";
   e.dataTransfer.setData("text", e.target.dataset.tileId);
 };
-
-let handleDragOver = e => {
-  if (e.preventDefault) e.preventDefault();
-  e.dataTransfer.dropEffect = "move";
-  return false;
-};
-
-const handleDragEnter = e => {
-  e.preventDefault();
-  e.target.classList.add("over");
-};
-
-const handleDragLeave = e => {
-  e.preventDefault();
-  e.target.classList.remove("over");
-};
-
-const handleDrop = e => {
-  e.preventDefault();
-  let primaryDestinationCell = e.target;
-  primaryDestinationCell.classList.remove("over");
-  primaryDestinationCell.classList.add("filled");
-
-  let id = e.dataTransfer.getData('text');
-  let primaryTile = document.querySelector(`.tile[data-tile-id="${id}"]`);
-  primaryTile.dataset.row = primaryTile.parentElement.dataset.row;
-  primaryTile.dataset.column = primaryTile.parentElement.dataset.column;
-  
-  e.target.appendChild(primaryTile);
-  primaryTile.dataset.destinationRow = primaryDestinationCell.dataset.row;
-  primaryTile.dataset.destinationColumn = primaryDestinationCell.dataset.column;
-
- 
-      const rowChange = Number(primaryTile.dataset.destinationRow) - Number(primaryTile.dataset.row);
-      const columnChange = Number(primaryTile.dataset.destinationColumn) - Number(primaryTile.dataset.column);
-        // calculate new coors for secondary cells. (origins + dist = targets)
-        tilesToDrag.forEach(tileData => {
-          secondaryTile = document.querySelector(`.tile[data-tile-id="${tileData.id}"]`);
-          secondaryTile.dataset.row = secondaryTile.parentElement.dataset.row;
-          secondaryTile.dataset.column = secondaryTile.parentElement.dataset.column;
-
-          secondaryTile.dataset.destinationRow = rowChange + Number(secondaryTile.dataset.row);
-          secondaryTile.dataset.destinationColumn = columnChange + Number(secondaryTile.dataset.column);
-
-          let secondaryDestination = document.querySelector( `#board .cell[data-row="${secondaryTile.dataset.destinationRow}"][data-column="${secondaryTile.dataset.destinationColumn}"]`);
-          secondaryDestination.appendChild(secondaryTile);
-        })
-  
-  tilesToDrag = [];
-  cleanBench();
-  resetModifiers('tile');
-}
 
 const handleDragEnd = e => {
   e.target.style.opacity = "";

--- a/static/scripts/populate.js
+++ b/static/scripts/populate.js
@@ -1,0 +1,89 @@
+/* Populate the board. */
+
+const populateBoard = () => {
+  let board = document.getElementById("board");
+  for (let r=0; r < rows; r++) {
+    for (let c=0; c < columns; c++) {
+      board.innerHTML += `<div class="cell" data-row=${r} data-column=${c}></div>`;
+    }
+  }
+
+  // Attach the listeners to the grid cells
+  document.querySelectorAll(".cell").forEach((cell) => {
+    cell.addEventListener("dragenter", handleDragEnter, options);
+    cell.addEventListener("dragleave", handleDragLeave, options);
+    cell.addEventListener("dragover", handleDragOver, options);
+
+    cell.addEventListener("dragend", handleDragEndBoard, options);
+    cell.addEventListener("drop", handleDrop, options);
+  });
+
+  centerBoard();
+};
+
+const centerBoard = () => {
+  const boardViewport = document.getElementById("board-viewport");
+  const board = document.getElementById("board");
+  const scrollPositionX =  board.offsetLeft + (board.offsetWidth / 2);
+  const scrollPositionY = board.offsetTop + (board.offsetHeight / 3);
+  boardViewport.scrollLeft = scrollPositionX;
+  boardViewport.scrollTop = scrollPositionY;
+}
+
+const handleDragEnter = e => {
+  e.preventDefault();
+  e.target.classList.add("over");
+};
+
+
+const handleDragLeave = e => {
+  e.preventDefault();
+  e.target.classList.remove("over");
+};
+
+let handleDragOver = e => {
+  if (e.preventDefault) e.preventDefault();
+  e.dataTransfer.dropEffect = "move";
+  return false;
+};
+
+const handleDragEndBoard = e => {
+  e.target.style.opacity = "";
+}
+
+const handleDrop = e => {
+  e.preventDefault();
+  let primaryDestinationCell = e.target;
+  primaryDestinationCell.classList.remove("over");
+  primaryDestinationCell.classList.add("filled");
+
+  let id = e.dataTransfer.getData('text');
+  let primaryTile = document.querySelector(`.tile[data-tile-id="${id}"]`);
+  primaryTile.dataset.row = primaryTile.parentElement.dataset.row;
+  primaryTile.dataset.column = primaryTile.parentElement.dataset.column;
+
+  e.target.appendChild(primaryTile);
+  primaryTile.dataset.destinationRow = primaryDestinationCell.dataset.row;
+  primaryTile.dataset.destinationColumn = primaryDestinationCell.dataset.column;
+
+      const rowChange = Number(primaryTile.dataset.destinationRow) - Number(primaryTile.dataset.row);
+      const columnChange = Number(primaryTile.dataset.destinationColumn) - Number(primaryTile.dataset.column);
+        // calculate new coors for secondary cells. (origins + dist = targets)
+        tilesToDrag.forEach(tileData => {
+          secondaryTile = document.querySelector(`.tile[data-tile-id="${tileData.id}"]`);
+          secondaryTile.dataset.row = secondaryTile.parentElement.dataset.row;
+          secondaryTile.dataset.column = secondaryTile.parentElement.dataset.column;
+
+          secondaryTile.dataset.destinationRow = rowChange + Number(secondaryTile.dataset.row);
+          secondaryTile.dataset.destinationColumn = columnChange + Number(secondaryTile.dataset.column);
+
+          let secondaryDestination = document.querySelector( `#board .cell[data-row="${secondaryTile.dataset.destinationRow}"][data-column="${secondaryTile.dataset.destinationColumn}"]`);
+          secondaryDestination.appendChild(secondaryTile);
+        })
+
+  tilesToDrag = [];
+  cleanBench();
+  resetModifiers('tile');
+}
+
+populateBoard();

--- a/templates/game.html
+++ b/templates/game.html
@@ -67,6 +67,7 @@
     
         </div>
         <script src="{{url_for('static', filename='scripts/board.js')}}"></script>
+        <script async src="{{url_for('static', filename='scripts/populate.js')}}"></script>
     </div>
 </body>
 


### PR DESCRIPTION
Moves all the board populating functionality to a separate file which is then loaded asynchronously on the front end. It seems to work very well in testing. The lobby loads almost immediately while the grid continues to load in the background. I'm not sure about the implications in terms of browser compatibility so that will need to be checked. This may also allow us to push the limits even further in terms of board size, but this would also need further testing.