### PR TITLE
Add dragging toggle on endgame, closes #33

### DIFF
--- a/static/scripts/board.js
+++ b/static/scripts/board.js
@@ -278,6 +278,18 @@ const setPosition = ({ top, left }) => {
   toggleMenu('show');
 };
 
+const enableDragging = () => {
+  document.querySelectorAll(".tile").forEach(tile => {
+    tile.draggable = true;
+  });
+}
+
+const disableDragging = () => {
+  document.querySelectorAll(".tile").forEach(tile => {
+    tile.draggable = false;
+  });
+}
+
 
 /*
   Ben Code
@@ -376,7 +388,7 @@ function render_game(resp) {
     } // Can no longer peel
     else if (resp["state"] == "ENDGAME") {
         hideButtons();
-        
+        enableDragging();
         $("#message").innerHTML = "<p>Almost done! Be the first to complete your board.</p>";
         $("#options").show();
         $("#bananagrams_button").show();
@@ -384,6 +396,7 @@ function render_game(resp) {
     } // Game over
     else if (resp["state"] == "OVER") {
         hideButtons();
+        disableDragging();
         $("#message").innerHTML =
             "<p>Game over? Check the winning board. If it's a false alarm, click 'Continue Game,' otherwise, click 'Reset Game' to play again.</p>"
         $("#options").show();


### PR DESCRIPTION
Add toggling to the drag state to ensure that players cannot continue to move tiles once someone has ended the game.