### PR TITLE
Fix multi tile operations

### DIFF
--- a/frontend/src/components/game/BoardCell.vue
+++ b/frontend/src/components/game/BoardCell.vue
@@ -44,7 +44,7 @@ const hasTile = computed(() => !!tile.value)
 
 function handleDragEnter(e: DragEvent) {
   e.preventDefault()
-  if (uiStore.isDragging && !hasTile.value) {
+  if (uiStore.isDragging) {
     isDragOver.value = true
   }
 }
@@ -55,7 +55,7 @@ function handleDragLeave() {
 
 function handleDragOver(e: DragEvent) {
   e.preventDefault()
-  if (uiStore.isDragging && !hasTile.value && e.dataTransfer) {
+  if (uiStore.isDragging && e.dataTransfer) {
     e.dataTransfer.dropEffect = 'move'
   }
 }
@@ -64,7 +64,7 @@ function handleDrop(e: DragEvent) {
   e.preventDefault()
   isDragOver.value = false
 
-  if (!uiStore.dragData || hasTile.value) return
+  if (!uiStore.dragData) return
 
   handleCellDrop(props.row, props.col)
 }
@@ -87,6 +87,12 @@ function handleDrop(e: DragEvent) {
     background-color: #e8f5e9;
     border-color: #4CAF50;
     box-shadow: inset 0 0 0 2px #4CAF50;
+
+    &.has-tile {
+      background-color: #fff3e0;
+      border-color: #ff9800;
+      box-shadow: inset 0 0 0 2px #ff9800;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Fix a bug where certain multi-tile drop operations were not working correctly and being blocked even though they were valid moves. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced drag-and-drop interactions now allow tiles to be dropped onto occupied cells, with new visual cues distinguishing these cells during drag-over.
* **Bug Fixes**
  * Improved multi-tile move handling to prevent conflicts and ensure moves are processed atomically, reducing errors and unintended behavior during complex drag-and-drop actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->